### PR TITLE
Libz Symbol correction PR

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -75,7 +75,7 @@ WriteMakefile(
     NAME         => 'Compress::Raw::Zlib',
     VERSION_FROM => 'lib/Compress/Raw/Zlib.pm',
     INC          => "-I$ZLIB_INCLUDE" ,
-    DEFINE       => "-DNO_VIZ -DZ_SOLO $OLD_ZLIB $WALL -DGZIP_OS_CODE=$GZIP_OS_CODE $USE_PPPORT_H" ,
+    DEFINE       => "-DNO_VIZ -DZ_SOLO $OLD_ZLIB $WALL -DZ_PREFIX -DGZIP_OS_CODE=$GZIP_OS_CODE $USE_PPPORT_H" ,
     XS           => { 'Zlib.xs' => 'Zlib.c'},
     'depend'     => { 'Makefile'   => 'config.in' },
     'clean'      => { FILES        => '*.c constants.h constants.xs' },


### PR DESCRIPTION
First attempt at working around https://github.com/pmqs/Compress-Raw-Zlib/issues/8 by enabling DPREFIX, which prefixes all libz (zlib-src/) symbols with z_, which should correct any symbol conflicts.

XXX: It might be worthwhile to change the z_ prefix to something unique to C::R::Zlib, ie: crz_