### PR TITLE
Fix test count regression in t/07bufsize.t

### DIFF
--- a/t/07bufsize.t
+++ b/t/07bufsize.t
@@ -24,7 +24,7 @@ BEGIN
     $extra = 1
         if eval { require Test::NoWarnings ;  import Test::NoWarnings; 1 };
 
-    plan tests => 280 + $extra ;
+    plan tests => 288 + $extra ;
 
     use_ok('Compress::Raw::Zlib', 2) ;
 }


### PR DESCRIPTION
Commit 8af98773 (zlib-ng support) changed the test count from 288 to 280. However, the number of tests did not actually change. There are two initial tests prior to a loop of 13 iterations containing 22 tests per iteration. Hence the total number of tests is  2+13*22 = 288.