### PR TITLE
[doc] zlib.h: Remove duplicate "the"

### DIFF
--- a/zlib-src/zlib.h
+++ b/zlib-src/zlib.h
@@ -729,7 +729,7 @@ ZEXTERN int ZEXPORT deflateParams OF((z_streamp strm,
    Then no more input data should be provided before the deflateParams() call.
    If this is done, the old level and strategy will be applied to the data
    compressed before deflateParams(), and the new level and strategy will be
-   applied to the the data compressed after deflateParams().
+   applied to the data compressed after deflateParams().
 
      deflateParams returns Z_OK on success, Z_STREAM_ERROR if the source stream
    state was inconsistent or if a parameter was invalid, or Z_BUF_ERROR if


### PR DESCRIPTION
Fix spelling in the comment